### PR TITLE
Compute relative path using output directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,7 +173,7 @@ class EleventyPluginRollup {
 
     // calculate script src after bundling
     const relativePath = path.relative(
-      eleventyInstance.page.outputPath,
+      path.dirname(eleventyInstance.page.outputPath),
       path.join(this.rollupConfig.output.dir, this.inputFiles[src])
     );
 


### PR DESCRIPTION
* Changes the relative path to go from the output directory to the output file (fixes #8)