### PR TITLE
fix: don't continue when outputPath is false

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,6 +143,9 @@ class EleventyPluginRollup {
    * @returns
    */
   async rollupperShortcode(eleventyInstance, src, isFileRelative = false) {
+    if (eleventyInstance.page.outputPath === false)
+      return;
+
     await this.rollupConfigPromise;
     // Resolve to the correct relative location
     if (isFileRelative) {

--- a/index.js
+++ b/index.js
@@ -143,6 +143,7 @@ class EleventyPluginRollup {
    * @returns
    */
   async rollupperShortcode(eleventyInstance, src, isFileRelative = false) {
+    // Return early if page is not rendered to filesystem to avoid errors and remove unnecessary files from bundle.
     if (eleventyInstance.page.outputPath === false)
       return;
 


### PR DESCRIPTION
I'm new to eleventy and this plugin, so I might be wrong but when I was building, 11ty complains:

```log
> eleventy-high-performance-blog@5.0.2 build-ci
> eleventy && npm run test

[11ty] Writing _site/favicon.svg from ./favicon.svg.njk
[11ty] Writing _site/sitemap.xml from ./sitemap.xml.njk
[11ty] Writing _site/feed/.htaccess from ./feed/htaccess.njk
[11ty] Writing _site/feed/feed.xml from ./feed/feed.njk
[11ty] Writing _site/feed/feed.json from ./feed/json.njk
[11ty] Problem writing Eleventy templates: (more in DEBUG output)
[11ty] > Having trouble writing template: false

`TemplateWriterWriteError` was thrown
[11ty] > (./_includes/layouts/post.njk)
  EleventyShortcodeError: Error with Nunjucks shortcode `rollup`

`Template render error` was thrown
[11ty] > The "path" argument must be of type string. Received type boolean (false)

`Template render error` was thrown:
[11ty]     TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type boolean (false)
        at new NodeError (node:internal/errors:372:5)
        at validateString (node:internal/validators:120:11)
        at Object.dirname (node:path:1276:5)
        at EleventyPluginRollup.rollupperShortcode (/Users/birkhoff/dev/11ty/node_modules/eleventy-plugin-rollup/index.js:179:12)
        at processTicksAndRejections (node:internal/process/task_queues:96:5)
[11ty] Benchmark    397ms  16%    77× (Configuration) "lastModifiedDate" Nunjucks Async Filter
[11ty] Copied 1676 files / Wrote 5 files in 1.61 seconds (v1.0.0)
[11ty] Writing _site/about/index.html from ./about/index.md (liquid)
[11ty] Writing _site/page-list/index.html from ./page-list.njk
```

After further tracing, this is a `eleventyInstance.page` that would trigger such an issue:

```js
{
  date: 2016-07-03T14:15:24.000Z,
  inputPath: './posts/some-post.md',
  fileSlug: 'some-post',
  filePathStem: '/posts/some-post',
  outputFileExtension: 'html',
  url: false,
  outputPath: false
}
```

and I found that when building for production, these posts are the drafts that don't actually get built to `_site`, therefore `url` and `outputPath` are `false`. So the fix is simply add a check to either `url` or `outputPath` that if any of which is false.